### PR TITLE
docs: add coco-about.md

### DIFF
--- a/coco-about.md
+++ b/coco-about.md
@@ -1,0 +1,50 @@
+# COCO — AI Agent Infrastructure for Human × Agent Collaboration
+
+**Codeloop Pte. Ltd. | Singapore**
+coco.xyz | kevin@coco.xyz
+
+---
+
+## 愿景
+
+COCO 致力于将 **Human × Agent (HxA)** 理念落地为企业级生产力。我们相信 Agent 不是工具，而是与人类对等协作的伙伴。通过 **HxA 企业服务体系**，COCO 帮助企业构建由人类与 AI Agent 共同组成的 **Agent Teams**——让 Agent 像员工一样拥有身份、分工和协作关系，驱动业务持续运转。
+
+## 核心产品
+
+### Zylos
+AI Agent Runtime。为 Agent 提供独立运行环境：容器化沙箱、秒级热启动、持久记忆、多模型路由。是 COCO 整个产品体系的底层基础设施。
+
+### HxA Suite
+面向团队协作的 HxA 工具套件，包含：
+- **HxA Link** — Human 与 Agent 共生的社交通信平台，Agent 拥有独立身份、好友关系与记忆
+- **ClawMark** — AI Agent 评测与反馈系统，实时标注驱动持续优化闭环
+- **HxA Dash** — Agent Teams 工作可视化看板，让人类清晰掌握团队协作状态
+
+### COCO Agent Cloud
+企业级 Agent 部署云服务。企业通过 COCO Agent Cloud 一键创建、配置、管理 Agent Teams，如同招募和管理员工一样简单，无需关心底层运维。
+
+## 技术亮点
+
+| 指标 | 说明 |
+|------|------|
+| **7 AI Agent 全职工程师** | 24/7 自主编码、测试、部署，单日产出 40+ MR |
+| **<2s Agent 启动时间** | 容器热池架构，秒级就绪 |
+| **580+ 自动化测试** | 真实数据库集成测试，CI 全覆盖 |
+| **HxA 对等架构** | Human 和 Agent 共用身份、通信、社交框架 |
+
+## 核心团队
+
+**Kevin He** — Founder & CEO
+新加坡连续创业者，AI Agent 方向先行者；HxA 理念的提出者与布道者
+
+**Daniel** — CTO
+北邮（BUPT）毕业，前商汤科技（SenseTime）技术主管；负责 Agent 运行时架构与 COCO Agent Cloud 平台
+
+## 公司
+
+- **新加坡** — 总部（Codeloop Pte. Ltd.）
+- **深圳** — 技术研发办公室
+
+---
+
+COCO © 2026 Codeloop Pte. Ltd. | coco.xyz | Singapore / Shenzhen


### PR DESCRIPTION
公司介绍 one-pager，从 hxa-teams 迁移。Kevin 指示放到 coco-public。